### PR TITLE
Responsive comment load if smaller than breakpoint

### DIFF
--- a/js/unison-responsive-comments.js
+++ b/js/unison-responsive-comments.js
@@ -35,16 +35,13 @@ Unison.ConditionalLoad = (function() {
       var minOrMax = 'min';
       //Test if breakpoint set, then test if it's a larger-than or smaller-than breakpoint. 
       if(!window.matchMedia){
-      		mediaMatch = noMatchMediaSize
+      	mediaMatch = noMatchMediaSize
       }else if(usnCL.breakpoints[node.breakpointMin] != undefined) {
-      		mediaMatch = usnCL.breakpoints[node.breakpointMin];
-      		console.log('breakpointMin '+usnCL.breakpoints[node.breakpointMin]);
+      	mediaMatch = usnCL.breakpoints[node.breakpointMin];
       } else {
-      		mediaMatch = usnCL.breakpoints[node.breakpointMax];
-      		var minOrMax = 'max';
-      		console.log('breakpointMax '+usnCL.breakpoints[node.breakpointMax]);
+      	mediaMatch = usnCL.breakpoints[node.breakpointMax];
+      	var minOrMax = 'max';
       }
-
       if( window.matchMedia('(' + minOrMax + '-width: ' + mediaMatch + ')').matches && node.element.getAttribute('title') !== 'loaded' ) {
         insertNode.apply(node);
         return;
@@ -115,5 +112,5 @@ Unison.ConditionalLoad = (function() {
     window.addEventListener('resize', debounce(testNodes.bind(nodes), 250));
     window.addEventListener('load', testNodes.bind(nodes));
   });
-
+  
 })();


### PR DESCRIPTION
Now you can specify to load commented content if current screen size is either smaller OR larger than the specified breakpoints. Previously, commented content could only be loaded in if larger than a specified breakpoint. 

This is done with the data attribute names in triggerMin (_data-usn-load-if-larger_)  & triggerMax  (_data-usn-load-if-smaller_). 

This would load if larger than the specified breakpoint:

```
<div data-usn-load-if-larger="usn-sml-med">
    <!-- content -->
</div>
```

This would load if smaller than the specified breakpoint:

```
<div data-usn-load-if-smaller="usn-sml-med">
    <!-- content -->
</div>
```

I know the original Responsive Comments JS was created to be 'progressive enhancement only', but often IMHO there is a good reason to load in different content & media on smaller devices.
