### PR TITLE
Update bower.json to reflect the tagged versions

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "Unison",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "homepage": "http://bjork24.github.io/Unison/",
   "authors": [
     "Dan Chilton <dan.chilton@gmail.com>"


### PR DESCRIPTION
There are currently two tags in the repo, `0.5.0` and `0.6.0`. I guess the `bower.json` file should be updated to reflect the latest version?
